### PR TITLE
Swagger API with swagger 1.5.4 - Close #28

### DIFF
--- a/ba-services/ba-services-rest-impl-jaxrs/pom.xml
+++ b/ba-services/ba-services-rest-impl-jaxrs/pom.xml
@@ -109,12 +109,6 @@
             </plugin>
 
             <plugin>
-                <!--
-                For version 8-
-                <groupId>org.mortbay.jetty</groupId>
-                For version 8+
-                <groupId>org.eclipse.jetty</groupId>
-                -->
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty-maven-plugin.version}</version>
@@ -126,22 +120,10 @@
                     <webApp>
                         <contextPath>/cxf</contextPath>
                     </webApp>
-
-                    <!-- Config for Jetty 8+ -->
                     <httpConnector>
                         <port>9191</port>
                         <idleTimeout>60000</idleTimeout>
                     </httpConnector>
-
-                    <!-- Config for Jetty 7-
-                    <connectors>
-                        <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                            <port>9191</port>
-                            <maxIdleTime>60000</maxIdleTime>
-                        </connector>
-                    </connectors>
-                    -->
-
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -149,9 +131,7 @@
                         <artifactId>slf4j-api</artifactId>
                         <version>${slf4j.version}</version>
                     </dependency>
-
                 </dependencies>
-
                 <executions>
                     <execution>
                         <id>start-jetty</id>
@@ -161,7 +141,6 @@
                         </goals>
                         <configuration>
                             <scanIntervalSeconds>0</scanIntervalSeconds>
-                            <!--<daemon>true</daemon>-->
                         </configuration>
                     </execution>
                     <execution>
@@ -236,7 +215,7 @@
                         <artifactId>mysql-connector-java</artifactId>
                         <version>${mysql-connector-java.version}</version>
                     </dependency>
-                    <!-- -->
+
                     <dependency>
                         <groupId>org.hsqldb</groupId>
                         <artifactId>hsqldb</artifactId>
@@ -258,12 +237,6 @@
                     <username>${deployment.jdbcUserName}</username>
                     <password>${deployment.jdbcPassword}</password>
                     <src>${deployment.createBankAccounts}</src>
-
-                    <!--
-                    <schema>gestimmo</schema>
-                    <dataTypeFactoryName>${deployment.dataTypeFactory}</dataTypeFactoryName>
-                    <metadataHandlerName>${deployment.metadataHandler}</metadataHandlerName>
-                    -->
                 </configuration>
 
                 <!-- Executions-->
@@ -298,7 +271,7 @@
             <plugin>
                 <groupId>org.jolokia</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.13.6</version>
+                <version>${docker-maven-plugin.version}</version>
                 <configuration>
                     <logDate>default</logDate>
                     <verbose>true</verbose>
@@ -321,7 +294,6 @@
                         </image>
                     </images>
                 </configuration>
-
             </plugin>
         </plugins>
 
@@ -378,6 +350,12 @@
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
             <version>${cxf.version}</version>
         </dependency>
@@ -389,9 +367,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-security-cors</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+
+        <dependency>
           <groupId>javax.servlet</groupId>
           <artifactId>javax.servlet-api</artifactId>
-          <version>3.1.0</version>
+          <version>${javax.servlet-api.version}</version>
           <scope>provided</scope>
         </dependency>
 
@@ -446,15 +430,15 @@
         </dependency>
 
         <dependency>
-            <groupId>com.wordnik</groupId>
-            <artifactId>swagger-jaxrs_2.10</artifactId>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
             <version>${swagger-jaxrs.version}</version>
-            <exclusions>
-                <exclusion>
-                     <groupId>javax.ws.rs</groupId>
-                     <artifactId>jsr311-api</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-jaxrs.version}</version>
         </dependency>
 
         <!-- Springframework Dependencies  - START -->
@@ -543,6 +527,7 @@
             <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
+        
         <!-- TESTING FRAMEWORKS: Cucumber for U.A. - END -->
 
         <!-- EXTERNAL PROJECT DEPENDENCIES - END -->

--- a/ba-services/ba-services-rest-impl-jaxrs/src/main/java/name/marmac/bankanalyzer/services/rest/server/impl/jaxrs/BankAccountsServicesImplJaxrs.java
+++ b/ba-services/ba-services-rest-impl-jaxrs/src/main/java/name/marmac/bankanalyzer/services/rest/server/impl/jaxrs/BankAccountsServicesImplJaxrs.java
@@ -1,8 +1,8 @@
 package name.marmac.bankanalyzer.services.rest.server.impl.jaxrs;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import name.marmac.bankanalyzer.dal.api.BankAccountsPersistenceServices;
 import name.marmac.bankanalyzer.model.api.BankAccountPO;
 import name.marmac.bankanalyzer.model.api.TransactionPO;
@@ -229,7 +229,7 @@ public class BankAccountsServicesImplJaxrs implements BankAccountsServices {
     @Produces({"application/xml", "application/json" })
     @Path("/bankaccounts/{iban}/transactions")
     @ApiOperation(value = "Get Transactions for a given Bank Account's iban, filtering them by some parameters in AND condition",
-                    notes = "Retrieve method",
+                    notes = "Retrieve method, filtering with parameters",
                     response = TransactionsTOType.class)
     public TransactionsTOType getTransactionsByBankAccount(@ApiParam(value = PATH_PARAM_IBAN,           required = true)                        @PathParam(PATH_PARAM_IBAN)     String iban,
                                                            @ApiParam(value = QUERY_PARAM_LIMIT,         required = false, allowMultiple = true) @QueryParam(QUERY_PARAM_LIMIT)  Integer limit,
@@ -240,8 +240,8 @@ public class BankAccountsServicesImplJaxrs implements BankAccountsServices {
                                                            @ApiParam(value = QUERY_PARAM_CURRENCY,      required = false, allowMultiple = true) @QueryParam("currency") String currency) {
 
         LOGGER.debug("getTransactionsByBankAccount");
-        SearchCondition<SearchBean> sc = searchContext.getCondition(SearchBean.class);
-        LOGGER.debug(sc.toString());
+        //SearchCondition<SearchBean> sc = searchContext.getCondition(SearchBean.class);
+        //LOGGER.debug(sc.toString());
 
         List<TransactionPO> transactionsPO = bankAccountsPersistenceServices.getAllTransactionsByBankAccount(iban);
         //Convert the TransactionsPO (list) into TransactionsTO (list)
@@ -344,6 +344,4 @@ public class BankAccountsServicesImplJaxrs implements BankAccountsServices {
 
         return transactionTO;
     }
-
-
 }

--- a/ba-services/ba-services-rest-impl-jaxrs/src/main/resources/rest-service-jaxrs-context.xml
+++ b/ba-services/ba-services-rest-impl-jaxrs/src/main/resources/rest-service-jaxrs-context.xml
@@ -40,36 +40,41 @@
 
     <!-- REST SERVICE ENDPOINT CONFIGURATION - START -->
         <!-- To browse:
-            - the services go to: http://host:port/cxf/api/v1
-            - the wadl go to: http://host:port/cxf/api/v1?_wadl
-            - the swagger api: http://host:port/cxf/api/v1/api-docs (as basepath set below)
+            - the services go to: http://host:port/<web_context>/api/v1
+            - the wadl go to: http://host:port/<web_context>/api/v1?_wadl
+            - the swagger api: http://host:port/<web_context>/api/v1/swagger.json (as basepath set below)
 
             where for default karaf installation:
             - host: karaf_host_ip or karaf_host_name
             - port: 8181
+            - <web_context> is:
+                - cxf when running with maven in the build
+                - war_name when the war is deployed in jetty_home/webapps
         -->
     <jaxrs:server
             address="/api/v1"
             bus="cxf"
-            staticSubresourceResolution="true">
+            staticSubresourceResolution="true" >
 
         <jaxrs:serviceBeans>
             <ref bean="bankAccountsServices"/>
+            <!-- This provides the Swagger resource listing, ie /swagger.json -->
+            <ref bean="swagger.apilisting" />
         </jaxrs:serviceBeans>
 
-        <!--
-        <jaxrs:schemaLocations>
-            <jaxrs:schemaLocation>classpath:WEB-INF/wadl/customerprovisioning.wadl</jaxrs:schemaLocation>
-            <jaxrs:schemaLocation>classpath:xsd/customers.xsd</jaxrs:schemaLocation>
-        </jaxrs:schemaLocations>
-        -->
-        <jaxrs:providers>
-            <ref bean="jaxbProvider"/>
-            <ref bean="jsonjaxbProvider" />
-            <ref bean="searchContextProvider"/>
 
-            <ref bean="resourceWriter"/>
-            <ref bean="apiWriter"/>
+        <jaxrs:schemaLocations>
+            <jaxrs:schemaLocation>classpath:WEB-INF/wadl/BankAccountServices.wadl</jaxrs:schemaLocation>
+            <jaxrs:schemaLocation>classpath:xsd/bankaccounts.xsd</jaxrs:schemaLocation>
+            <jaxrs:schemaLocation>classpath:xsd/transactions.xsd</jaxrs:schemaLocation>
+        </jaxrs:schemaLocations>
+
+        <jaxrs:providers>
+            <ref bean="cors-filter" />
+            <ref bean="jaxbProvider"            />
+            <ref bean="jsonjaxbProvider"        />
+            <ref bean="searchContextProvider"   />
+            <ref bean="swagger.serializers"     />
         </jaxrs:providers>
 
         <jaxrs:features>
@@ -98,6 +103,8 @@
 
     </bean>
 
+    <bean id="cors-filter" class="org.apache.cxf.rs.security.cors.CrossOriginResourceSharingFilter"/>
+
     <!-- XML Provider with JAXB2 -->
     <bean id="jaxbProvider" class="org.apache.cxf.jaxrs.provider.JAXBElementProvider">
         <property name="marshallAsJaxbElement" value="true"/>
@@ -109,24 +116,19 @@
     <!-- -->
     <bean id="searchContextProvider" class="org.apache.cxf.jaxrs.ext.search.SearchContextProvider"/>
 
+
 <!-- SWAGGER SPECIFIC CONFIGURATION - START -->
-    <bean id="swaggerResourceJSON"  class="com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON" />
-    <bean id="apiWriter"            class="com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider" />
-    <bean id="resourceWriter"       class="com.wordnik.swagger.jaxrs.listing.ResourceListingProvider" />
+    <!-- Swagger resources -->
+    <bean id="swagger.apilisting" class="io.swagger.jaxrs.listing.ApiListingResource" />
+    <bean id="swagger.serializers" class="io.swagger.jaxrs.listing.SwaggerSerializers" />
 
-
-    <!-- Swagger configuration -->
-    <bean id="swaggerConfig" class="com.wordnik.swagger.jaxrs.config.BeanConfig">
-        <property name="title"              value="BANK ACCOUNTS SERVICES REST API"/>
-        <property name="version"            value="1.0.0"/>
-        <property name="basePath"           value="/swagger" />
-        <property name="resourcePackage"    value="name.marmac.bankanalyzer.services.rest.server.impl.jaxrs"/>
-        <property name="scan"               value="true"/>
-
-        <property name="description"        value="Bank Accounts Interface"/>
+    <bean id="swagger.config" class="io.swagger.jaxrs.config.BeanConfig">
+        <property name="resourcePackage"    value="name.marmac.bankanalyzer.services.rest.server.impl.jaxrs" />
+        <property name="version"            value="${project.parent.version}"/>
+        <property name="title"              value="BANK ANALYZER Services"/>
         <property name="contact"            value="marco.maccio@marmac.name"/>
-        <property name="license"            value="Apache 2.0 License"/>
-        <property name="licenseUrl"         value="http://www.apache.org/licenses/LICENSE-2.0.html"/>
+        <property name="scan"               value="true"/>
+        <property name="basePath"           value="/cxf/api/v1"/>
     </bean>
 
     <!-- Exception mapper

--- a/pom.xml
+++ b/pom.xml
@@ -190,9 +190,9 @@
         <fasterxml-jackson.version>2.6.3</fasterxml-jackson.version>
         
         <scala-library.version>2.10.2</scala-library.version>
-
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javaee-web-api.version>7.0</javaee-web-api.version>
-        <swagger-jaxrs.version>1.3.12</swagger-jaxrs.version>
+        <swagger-jaxrs.version>1.5.4</swagger-jaxrs.version>
 
         <slf4j.version>1.7.13</slf4j.version>
         <slf4j-log4j12.version>1.7.13</slf4j-log4j12.version>
@@ -225,14 +225,10 @@
         <h2.version>1.4.190</h2.version>
         <spring-test-dbunit.version>1.2.1</spring-test-dbunit.version>
 
-        <!--
-            OLDER V. 7.4.5.v20110725
-            7.6.14.v20131031
-            NEWER V. 8.1.14.v20131031
-            NEWER V. 9.2.3.v20140905
-        -->
         <jetty-maven-plugin.version>9.3.6.v20151106</jetty-maven-plugin.version>
-        <jetty.version>8.1.10.v20130312</jetty.version>
+        <jetty.version>9.3.6.v20151106</jetty.version>
+
+        <docker-maven-plugin.version>0.13.6</docker-maven-plugin.version>
 
         <!-- Monitoring libraries -->
         <java-melody-core.version>1.54.0</java-melody-core.version>
@@ -846,7 +842,7 @@
                 <deployment.createSchemaFilename>mysql-create-tables.sql</deployment.createSchemaFilename>
                 <deployment.dropSchemaFilename>mysql-drop-tables.sql</deployment.dropSchemaFilename>
                 <deployment.dataTypeFactory>org.dbunit.ext.h2.H2DataTypeFactory</deployment.dataTypeFactory>
-                <!-- -->
+                <deployment.metadataHandler/>
                 <deployment.createBankAccounts>src/integration-test/data/create-bankaccounts.xml</deployment.createBankAccounts>
 
                 <liquibase.contexts>integration-test</liquibase.contexts>


### PR DESCRIPTION
Migrate swagger to io.swagger:1.5.4 (current latest version) and
reconfigured the Spring context to properly show swagger api
documentation.
Added new cxf-rt-rs-service-description dependency to show wadl as in
cxf 3.x this was moved out the original jar cxf-rt-frontend-jaxrs.
Added cxf-rt-rs-security-cors to allow swagger-ui to connect to the
swagger-api exposed by the Jax-rs service.